### PR TITLE
Switch the network to bridge (default container network)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,8 @@ x-gpu-base-service: &gpu_service
 
 x-base_service: &base_service
   user: "${UID:-0}:${GID:-0}"
-  network_mode: "host"
-  #ports:
-  #  - "7680:7680"
+  ports:
+    - "127.0.0.1:7680:7680"
   build:
       context: ./kohya_ss
       args:
@@ -56,7 +55,7 @@ services:
       - XDG_CACHE_HOME=/data/.cache
       - ACCELERATE=False
       - DISPLAY=unix$DISPLAY
-      - RUN_ARGS=/koyah_ss/kohya_gui.py --server_port 7680
+      - RUN_ARGS=/koyah_ss/kohya_gui.py --listen 0.0.0.0 --server_port 7680
       #- RUN_ARGS=/koyah_ss/lora_gui.py
       - RUNNER=/docker/run.sh
       


### PR DESCRIPTION
In this way, accessing `127.0.0.1:7680` from the host you are able to access what the container listened on `0.0.0.0:7680`.

This should be more secure because the container is limited to ultimately only bind to `127.0.0.1:7680` from the host perspective, no matter what any script inside the container tries to do.