### PR TITLE
update cuda-drivers version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ x-base_service: &base_service
       TRITON_VERSION: "2.0.0"
       DEEPSPEED_VERSION: "0.9.2"
       CUDNN_VERSION: "8.6.0.163"
-      CUDA_VERSION: cuda-drivers-530 cuda-11-8
+      CUDA_VERSION: cuda-drivers-535 cuda-11-8
       DS_BUILD_OPS: 1
       TORCH_CUDA_ARCH_LIST: 7.5+PTX
       NVCC_FLAGS: --use_fast_math


### PR DESCRIPTION
apt-install gets held broken packages - needs update to cuda-drivers

>  => ERROR [kohya_cuda 2/2] RUN <<EOF (# cuda driver update...)        6.9s
> ------
>  > [kohya_cuda 2/2] RUN <<EOF (# cuda driver update...):
> #0 1.939 + apt-get update
> #0 2.667 Hit:1 https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64  InRelease
> #0 2.667 Hit:2 http://deb.debian.org/debian bookworm InRelease
> #0 2.667 Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
> #0 2.667 Hit:4 http://deb.debian.org/debian-security bookworm-security InRelease
> #0 3.595 Reading package lists...
> #0 4.901 W: Target Packages (Packages) is configured multiple times in /etc/apt/sources.list:8 and /etc/apt/sources.list.d/cuda-debian11-x86_64.list:1
> #0 4.901 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:4
> #0 4.901 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:4
> #0 4.901 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:5
> #0 4.901 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:5
> #0 4.901 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list.d/debian.sources:1
> #0 4.901 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list.d/debian.sources:1
> #0 4.901 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:4
> #0 4.901 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:4
> #0 4.901 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:5
> #0 4.901 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:5
> #0 4.901 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list.d/debian.sources:1
> #0 4.901 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list.d/debian.sources:1
> #0 4.901 W: Target Packages (Packages) is configured multiple times in /etc/apt/sources.list:8 and /etc/apt/sources.list.d/cuda-debian11-x86_64.list:1
> #0 4.902 + apt-get -y install cuda-drivers-530 cuda-11-8
> #0 4.944 Reading package lists...
> #0 5.506 Building dependency tree...
> #0 5.666 Reading state information...
> #0 5.756 Some packages could not be installed. This may mean that you have
> #0 5.756 requested an impossible situation or if you are using the unstable
> #0 5.756 distribution that some required packages have not yet been created
> #0 5.756 or been moved out of Incoming.
> #0 5.756 The following information may help to resolve the situation:
> #0 5.756
> #0 5.756 The following packages have unmet dependencies:
> #0 5.824  cuda-drivers : Depends: cuda-drivers-535 (= 535.54.03-1) but it is not installable
> #0 5.830 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:4
> #0 5.830 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:4
> #0 5.830 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:5
> #0 5.830 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list:5
> #0 5.830 W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list.d/debian.sources:1
> #0 5.830 W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:3 and /etc/apt/sources.list.d/debian.sources:1
> #0 5.830 W: Target Packages (Packages) is configured multiple times in /etc/apt/sources.list:8 and /etc/apt/sources.list.d/cuda-debian11-x86_64.list:1
> #0 5.830 E: Unable to correct problems, you have held broken packages.
> ------
> failed to solve: process "/bin/bash -ceuxo pipefail # cuda driver update\napt-get update\napt-get -y install $CUDA_VERSION\n" did not complete successfully: exit code: 100